### PR TITLE
Misc/additional extensions

### DIFF
--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Collections/IEnumeratorExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Collections/IEnumeratorExtensions.cs
@@ -1,0 +1,59 @@
+﻿/*
+MIT License
+
+Copyright (c) 2020 Dawid Dyrcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TeklaOpenAPIExtension.Collections
+{
+	public static class IEnumeratorExtensions
+	{
+		/// <summary>
+		/// Moves over elements within <paramref name="enumerator"/> and returns a <see cref="IReadOnlyCollection{TReturn}"/> of all elements of type <typeparamref name="TReturn"/>.
+		/// </summary>
+		/// <typeparam name="TReturn">The type of element to return.</typeparam>
+		/// <param name="enumerator">A generic enumerator of elements.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TReturn}"/> of typed elements from <paramref name="enumerator"/>.</returns>
+		/// <remarks><see cref="IEnumerator.Reset"/> will not be called on <paramref name="enumerator"/> during the execution of <see cref="ToEnumerable{TReturn}"/>.</remarks>
+		public static IReadOnlyCollection<TReturn> ToReadOnlyCollection<TReturn>(this IEnumerator enumerator)
+		{
+			return enumerator.ToEnumerable<TReturn>().ToArray();
+		}
+
+		/// <summary>
+		/// Moves over elements within <paramref name="enumerator"/> and returns all elements of type <typeparamref name="TReturn"/>.
+		/// </summary>
+		/// <typeparam name="TReturn">The type of element to return.</typeparam>
+		/// <param name="enumerator">A generic enumerator of elements.</param>
+		/// <returns>All elements of type <typeparamref name="TReturn"/> from <paramref name="enumerator"/>.</returns>
+		/// <remarks><see cref="IEnumerator.Reset"/> will not be called on <paramref name="enumerator"/> during the execution of <see cref="ToEnumerable{TReturn}"/>.</remarks>
+		private static IEnumerable<TReturn> ToEnumerable<TReturn>(this IEnumerator enumerator)
+		{
+			while (enumerator.MoveNext())
+				if (enumerator.Current is TReturn typedCurrent)
+					yield return typedCurrent;
+		}
+	}
+}

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/ContainerViewExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/ContainerViewExtensions.cs
@@ -1,0 +1,64 @@
+﻿/*
+MIT License
+
+Copyright (c) 2020 Dawid Dyrcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+If you dont want to have codes which need reference to the Tekla.Structures.Drawing.dll then
+open properties of your project, goto Build > Conditional compilation symbols and add symbol NOT_TSD
+With NOT_TSD symbol the code bellow will not be included in your project
+*/
+
+#if !NOT_TSD
+
+using System.Collections.Generic;
+using Tekla.Structures.Drawing;
+
+namespace TeklaOpenAPIExtension.Drawing
+{
+	public static class ContainerViewExtensions
+	{
+		/// <summary>
+		/// Gets all views of type <typeparamref name="TView"/> that are placed on <paramref name="containerView"/>.
+		/// </summary>
+		/// <typeparam name="TView">Type of returned views.</typeparam>
+		/// <param name="containerView">Container view which holds other views.</param>
+		/// <returns>All views placed on <paramref name="containerView"/> of type <typeparamref name="TView"/>.</returns>
+		public static IReadOnlyCollection<TView> GetViews<TView>(this ContainerView containerView) where TView : ViewBase
+		{
+			return containerView.GetViews().ToReadOnlyCollection<TView>();
+		}
+
+		/// <summary>
+		/// Gets all views of type <typeparamref name="TView"/> that are placed on <paramref name="containerView"/> and their children views.
+		/// </summary>
+		/// <typeparam name="TView">Type of returned views.</typeparam>
+		/// <param name="containerView">Container view which holds other views.</param>
+		/// <returns>All views and their children views placed on <paramref name="containerView"/> of type <typeparamref name="TView"/>.</returns>
+		public static IReadOnlyCollection<TView> GetAllViews<TView>(this ContainerView containerView) where TView : ViewBase
+		{
+			return containerView.GetAllViews().ToReadOnlyCollection<TView>();
+		}
+	}
+}
+
+#endif

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingEnumeratorExtension.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingEnumeratorExtension.cs
@@ -30,17 +30,25 @@ With NOT_TSD symbol the code bellow will not be included in your project
 
 #if !NOT_TSD
 
+using System.Collections;
 using System.Collections.Generic;
 using Tekla.Structures.Drawing;
+using TeklaOpenAPIExtension.Collections;
 
 namespace TeklaOpenAPIExtension
 {
     public static class DrawingEnumeratorExtension
     {
-        /// <summary>Add items from the enumerator to the System.Collections.Generic.List</summary>
-        public static List<Drawing> ToList(this DrawingEnumerator enumerator)
+		/// <inheritdoc cref="Collections.IEnumeratorExtensions.ToReadOnlyCollection{TDrawing}"/>
+		public static IReadOnlyCollection<TDrawing> ToReadOnlyCollection<TDrawing>(this DrawingEnumerator enumerator) where TDrawing : Tekla.Structures.Drawing.Drawing
         {
-            var output = new List<Drawing>(enumerator.GetSize());
+	        return ((IEnumerator)enumerator).ToReadOnlyCollection<TDrawing>();
+        }
+
+		/// <summary>Add items from the enumerator to the System.Collections.Generic.List</summary>
+		public static List<Tekla.Structures.Drawing.Drawing> ToList(this DrawingEnumerator enumerator)
+        {
+            var output = new List<Tekla.Structures.Drawing.Drawing>(enumerator.GetSize());
 
             while (enumerator.MoveNext())
             {
@@ -51,7 +59,7 @@ namespace TeklaOpenAPIExtension
         }
 
         /// <summary>Add items from the enumerator to the System.Collections.Generic.List. if (enumerator.Current is T t) output.Add(t);</summary>
-        public static List<T> ToList<T>(this DrawingEnumerator enumerator) where T : Drawing
+        public static List<T> ToList<T>(this DrawingEnumerator enumerator) where T : Tekla.Structures.Drawing.Drawing
         {
             var output = new List<T>(enumerator.GetSize());
 

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingObjectEnumeratorExtension.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingObjectEnumeratorExtension.cs
@@ -30,13 +30,21 @@ With NOT_TSD symbol the code bellow will not be included in your project
 
 #if !NOT_TSD
 
+using System.Collections;
 using System.Collections.Generic;
 using Tekla.Structures.Drawing;
+using TeklaOpenAPIExtension.Collections;
 
 namespace TeklaOpenAPIExtension
 {
     public static class DrawingObjectEnumeratorExtension
     {
+	    /// <inheritdoc cref="Collections.IEnumeratorExtensions.ToReadOnlyCollection{TDrawing}"/>
+		public static IReadOnlyCollection<TDrawingObject> ToReadOnlyCollection<TDrawingObject>(this DrawingObjectEnumerator enumerator) where TDrawingObject : DrawingObject
+        {
+            return ((IEnumerator)enumerator).ToReadOnlyCollection<TDrawingObject>();
+        }
+
         /// <summary>Adds items from the enumerator to the System.Collections.Generic.List</summary>
         public static List<DrawingObject> ToList(this DrawingObjectEnumerator enumerator)
         {

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingObjectSelectorExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingObjectSelectorExtensions.cs
@@ -39,7 +39,18 @@ using Tekla.Structures.Drawing.UI;
 namespace TeklaOpenAPIExtension
 {
     public static class DrawingObjectSelectorExtensions
-    {
+	{
+		/// <summary>
+		/// Gets the selected objects in the drawing of type <typeparamref name="TDrawingObject"/>.
+		/// </summary>
+		/// <typeparam name="TDrawingObject">Type of returned drawing objects.</typeparam>
+		/// <param name="selector">Selector to find drawing objects.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TDrawingObject}"/> of the selected objects in the drawing.</returns>
+		public static IReadOnlyCollection<TDrawingObject> GetSelected<TDrawingObject>(this DrawingObjectSelector selector) where TDrawingObject : DrawingObject
+	    {
+		    return selector.GetSelected().ToReadOnlyCollection<TDrawingObject>();
+	    }
+
         public static void SelectObjects(this DrawingObjectSelector selector, IEnumerable<DrawingObject> drawingObjects, bool extendSelection = false)
         {
             var arList = new ArrayList(drawingObjects.Count());

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingSelectorExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/DrawingSelectorExtensions.cs
@@ -1,0 +1,53 @@
+﻿/*
+MIT License
+
+Copyright (c) 2022 Dawid Dyrcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+If you dont want to have codes which need reference to the Tekla.Structures.Drawing.dll then
+open properties of your project, goto Build > Conditional compilation symbols and add symbol NOT_TSD
+With NOT_TSD symbol the code bellow will not be included in your project
+*/
+
+using System.Collections.Generic;
+using Tekla.Structures.Drawing.UI;
+
+#if !NOT_TSD
+
+namespace TeklaOpenAPIExtension.Drawing
+{
+	public static class DrawingSelectorExtensions
+	{
+		/// <summary>
+		/// Gets the drawings that are currently selected in the drawing list dialog of type <typeparamref name="TDrawing"/>.
+		/// </summary>
+		/// <typeparam name="TDrawing">Type of drawing to return.</typeparam>
+		/// <param name="selector">Selector to get all drawings from.</param>
+		/// <returns>The drawings that are currently selected in the drawing list dialog.</returns>
+		public static IReadOnlyCollection<TDrawing> GetSelected<TDrawing>(this DrawingSelector selector) where TDrawing : Tekla.Structures.Drawing.Drawing
+		{
+			return selector.GetSelected().ToReadOnlyCollection<TDrawing>();
+		}
+	}
+}
+
+#endif

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/ViewExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Drawing/ViewExtensions.cs
@@ -1,0 +1,66 @@
+﻿/*
+MIT License
+
+Copyright (c) 2022 Dawid Dyrcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+If you dont want to have codes which need reference to the Tekla.Structures.Drawing.dll then
+open properties of your project, goto Build > Conditional compilation symbols and add symbol NOT_TSD
+With NOT_TSD symbol the code bellow will not be included in your project
+*/
+
+#if !NOT_TSD
+
+using System.Collections.Generic;
+using Tekla.Structures;
+using Tekla.Structures.Drawing;
+
+namespace TeklaOpenAPIExtension.Drawing
+{
+	public static class ViewExtensions
+	{
+		/// <summary>
+		/// Gets the drawing model objects that are in the view of type <typeparamref name="TDrawingObject"/>.
+		/// </summary>
+		/// <typeparam name="TDrawingObject">Type of returned drawing model object.</typeparam>
+		/// <param name="view">View containing the model objects.</param>
+		/// <returns>The drawing model objects that are in the view.</returns>
+		public static IReadOnlyCollection<TDrawingObject> GetModelObjects<TDrawingObject>(this View view) where TDrawingObject : Tekla.Structures.Drawing.ModelObject
+		{
+			return view.GetModelObjects().ToReadOnlyCollection<TDrawingObject>();
+		}
+
+		/// <summary>
+		/// Gets the drawing model objects of type <typeparamref name="TDrawingObject"/> based on given model object identifier. If used from sheet model objects from all views are returned.
+		/// </summary>
+		/// <typeparam name="TDrawingObject">Type of returned drawing model object.</typeparam>
+		/// <param name="view">View containing the model objects.</param>
+		/// <param name="identifier">The identifier of the object in the model.</param>
+		/// <returns>The drawing model objects that are in the view.</returns>
+		public static IReadOnlyCollection<TDrawingObject> GetModelObjects<TDrawingObject>(this View view, Identifier identifier) where TDrawingObject : Tekla.Structures.Drawing.ModelObject
+		{
+			return view.GetModelObjects(identifier).ToReadOnlyCollection<TDrawingObject>();
+		}
+	}
+}
+
+#endif

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/ModelExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/ModelExtensions.cs
@@ -28,6 +28,8 @@ open properties of your project, goto Build > Conditional compilation symbols an
 With NOT_TSD symbol the code bellow will not be included in your project
 */
 
+using System;
+using ts = Tekla.Structures;
 using tsm = Tekla.Structures.Model;
 
 namespace TeklaOpenAPIExtension
@@ -38,9 +40,33 @@ namespace TeklaOpenAPIExtension
         {
             return model.GetInfo().ModelPath;
         }
+
         public static string AttributesPath(this tsm.Model model)
         {
             return System.IO.Path.Combine(model.GetInfo().ModelPath, "attributes");
         }
-    }
+
+        public static TModelObject Select<TModelObject>(this tsm.Model model, ts.Identifier identifier) where TModelObject : tsm.ModelObject
+        {
+            return model.SelectModelObject(identifier) as TModelObject;
+        }
+
+        public static bool TrySelect<TModelObject>(this tsm.Model model, ts.Identifier identifier, out TModelObject modelObject) where TModelObject : tsm.ModelObject
+        {
+	        modelObject = model.Select<TModelObject>(identifier);
+	        return modelObject != null;
+        }
+
+        public static TModelObject Select<TModelObject>(this tsm.Model model, Guid guid) where TModelObject : tsm.ModelObject
+        {
+	        var identifier = model.GetIdentifierByGUID(guid.ToString());
+	        return model.SelectModelObject(identifier) as TModelObject;
+        }
+
+        public static bool TrySelect<TModelObject>(this tsm.Model model, Guid guid, out TModelObject modelObject) where TModelObject : tsm.ModelObject
+        {
+	        modelObject = model.Select<TModelObject>(guid);
+	        return modelObject != null;
+        }
+	}
 }

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/ModelObjectEnumeratorExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/ModelObjectEnumeratorExtensions.cs
@@ -22,13 +22,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Tekla.Structures.Model;
+using TeklaOpenAPIExtension.Collections;
 
 namespace TeklaOpenAPIExtension
 {
     public static class ModelObjectEnumeratorExtensions
     {
+	    /// <inheritdoc cref="Collections.IEnumeratorExtensions.ToReadOnlyCollection{TDrawing}"/>
+		public static IReadOnlyCollection<TModelObject> ToReadOnlyCollection<TModelObject>(this ModelObjectEnumerator enumerator) where TModelObject : Tekla.Structures.Model.ModelObject
+        {
+            return ((IEnumerator)enumerator).ToReadOnlyCollection<TModelObject>();
+        }
+
         public static List<ModelObject> ToList(this ModelObjectEnumerator enumerator, bool selectInstances = false)
         {
             enumerator.SelectInstances = selectInstances;
@@ -83,7 +91,7 @@ namespace TeklaOpenAPIExtension
                 if (modelObject is T t)
                 {
                     if (!output.ContainsKey(modelObject.Identifier.GUID))
-                        output.Add(modelObject.Identifier.GUID, t); 
+                        output.Add(modelObject.Identifier.GUID, t);
                 }
             }
             return output;
@@ -116,7 +124,7 @@ namespace TeklaOpenAPIExtension
                 if (modelObject is T t)
                 {
                     if (!output.ContainsKey(modelObject.Identifier.ID))
-                        output.Add(modelObject.Identifier.ID, t); 
+                        output.Add(modelObject.Identifier.ID, t);
                 }
             }
             return output;

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/ModelObjectSelectorExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/ModelObjectSelectorExtensions.cs
@@ -1,0 +1,121 @@
+﻿/*
+MIT License
+
+Copyright (c) 2020 Dawid Dyrcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using Tekla.Structures.Filtering;
+using Tekla.Structures.Geometry3d;
+using Tekla.Structures.Model;
+
+namespace TeklaOpenAPIExtension.Model
+{
+	public static class ModelObjectSelectorExtensions
+	{
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of all the model objects in the current model with the given base type.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of all the model objects with the given types.</returns>
+		public static IReadOnlyCollection<TModelObject> GetAllObjects<TModelObject>(this ModelObjectSelector selector) where TModelObject : ModelObject
+		{
+			return selector.GetAllObjectsWithType(new[] { typeof(TModelObject) }).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of all the model objects in the current model with the given type. 
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="objectEnum">The type of the objects to return.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of all the model objects with the given type.</returns>
+		public static IReadOnlyCollection<TModelObject> GetAllObjects<TModelObject>(this ModelObjectSelector selector, ModelObject.ModelObjectEnum objectEnum) where TModelObject : ModelObject
+		{
+			return selector.GetAllObjectsWithType(objectEnum).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects in the current model with the given type and selected by the filter.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="objectEnum">The type of the objects to return.</param>
+		/// <param name="filterName">The name of an existing selection filter to apply.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects with the given type and selected by the filter.</returns>
+		public static IReadOnlyCollection<TModelObject> GetFilteredObjects<TModelObject>(this ModelObjectSelector selector, ModelObject.ModelObjectEnum objectEnum, string filterName) where TModelObject : ModelObject
+		{
+			return selector.GetFilteredObjectsWithType(objectEnum, filterName).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects of type <typeparamref name="TModelObject"/> in the current model selected by the given selection filter definition.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="expression">The definition of a selection filter to apply.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the objects selected by the filter.</returns>
+		public static IReadOnlyCollection<TModelObject> GetObjects<TModelObject>(this ModelObjectSelector selector, FilterExpression expression) where TModelObject : ModelObject
+		{
+			return selector.GetObjectsByFilter(expression).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects of type <typeparamref name="TModelObject"/> in the current model selected by the given selection filter.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="filterName">The name of an existing selection filter to apply.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the objects selected by the filter.</returns>
+		public static IReadOnlyCollection<TModelObject> GetObjects<TModelObject>(this ModelObjectSelector selector, string filterName) where TModelObject : ModelObject
+		{
+			return selector.GetObjectsByFilterName(filterName).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects in the current model colliding with the given geometrical bounding box.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="minPoint">The minimum point of the bounding box.</param>
+		/// <param name="maxPoint">The maximum point of the bounding box.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects colliding with the given bounding box.</returns>
+		/// <remarks>Note that this method uses approximate bounding boxes and thus is NOT EXACT, and may return objects not necessarily colliding with the given box but only being somewhere near to it.</remarks>
+		public static IReadOnlyCollection<TModelObject> GetObjectsByBoundingBox<TModelObject>(this ModelObjectSelector selector, Point minPoint, Point maxPoint) where TModelObject : ModelObject
+		{
+			return selector.GetObjectsByBoundingBox(minPoint, maxPoint).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects in the current model colliding with the given geometrical bounding box.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="bounds">The bounding box to check model objects against.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the model objects colliding with the given bounding box.</returns>
+		/// <remarks>Note that this method uses approximate bounding boxes and thus is NOT EXACT, and may return objects not necessarily colliding with the given box but only being somewhere near to it.</remarks>
+		public static IReadOnlyCollection<TModelObject> GetObjectsByBoundingBox<TModelObject>(this ModelObjectSelector selector, AABB bounds) where TModelObject : ModelObject
+		{
+			return selector.GetObjectsByBoundingBox(bounds.MinPoint, bounds.MaxPoint).ToReadOnlyCollection<TModelObject>();
+		}
+	}
+}

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/UI/ModelObjectSelectorExtensions.cs
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/Model/UI/ModelObjectSelectorExtensions.cs
@@ -1,0 +1,75 @@
+﻿/*
+MIT License
+
+Copyright (c) 2020 Dawid Dyrcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using Tekla.Structures.Geometry3d;
+using Tekla.Structures.Model.UI;
+using ModelObject = Tekla.Structures.Model.ModelObject;
+using ModelObjectSelector = Tekla.Structures.Model.UI.ModelObjectSelector;
+
+namespace TeklaOpenAPIExtension.Model.UI
+{
+	public static class ModelObjectSelectorExtensions
+	{
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the given view's visible model objects that collide with the given geometrical bounding box.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="bounds">The bounding box.</param>
+		/// <param name="view">The view to get the objects from.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the visible model objects colliding with the given bounding box.</returns>
+		/// <remarks>Note that this method uses approximate bounding boxes and thus is NOT EXACT, and may return objects not necessarily colliding with the given box but only being somewhere near to it.</remarks>
+		public static IReadOnlyCollection<TModelObject> GetObjectsByBoundingBox<TModelObject>(this ModelObjectSelector selector, AABB bounds, View view) where TModelObject : ModelObject
+		{
+			return selector.GetObjectsByBoundingBox(bounds.MinPoint, bounds.MaxPoint, view).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of the given view's visible model objects that collide with the given geometrical bounding box.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <param name="minPoint">The minimum point of the bounding box.</param>
+		/// <param name="maxPoint">The maximum point of the bounding box.</param>
+		/// <param name="view">The view to get the objects from.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of the visible model objects colliding with the given bounding box.</returns>
+		/// <remarks>Note that this method uses approximate bounding boxes and thus is NOT EXACT, and may return objects not necessarily colliding with the given box but only being somewhere near to it.</remarks>
+		public static IReadOnlyCollection<TModelObject> GetObjectsByBoundingBox<TModelObject>(this ModelObjectSelector selector, Point minPoint, Point maxPoint, View view) where TModelObject : ModelObject
+		{
+			return selector.GetObjectsByBoundingBox(minPoint, maxPoint, view).ToReadOnlyCollection<TModelObject>();
+		}
+
+		/// <summary>
+		/// Returns a <see cref="IReadOnlyCollection{TModelObject}"/> of all the selected model objects in the model view.
+		/// </summary>
+		/// <typeparam name="TModelObject">Type of the model objects to return.</typeparam>
+		/// <param name="selector">The model object selector to get objects from.</param>
+		/// <returns>A <see cref="IReadOnlyCollection{TModelObject}"/> of all the selected model objects.</returns>
+		public static IReadOnlyCollection<TModelObject> GetSelected<TModelObject>(this ModelObjectSelector selector) where TModelObject : ModelObject
+		{
+			return selector.GetSelectedObjects().ToReadOnlyCollection<TModelObject>();
+		}
+	}
+}

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
@@ -81,6 +81,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Collections\IEnumeratorExtensions.cs" />
     <Compile Include="Drawing\DrawingExtensions.cs" />
     <Compile Include="Drawing\DrawingObjectExtensions.cs" />
     <Compile Include="Drawing\DrawingObjectSelectorExtensions.cs" />

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
@@ -82,6 +82,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Collections\IEnumeratorExtensions.cs" />
+    <Compile Include="Drawing\ContainerViewExtensions.cs" />
     <Compile Include="Drawing\DrawingExtensions.cs" />
     <Compile Include="Drawing\DrawingObjectExtensions.cs" />
     <Compile Include="Drawing\DrawingObjectSelectorExtensions.cs" />

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Model\ModelObjectEnumeratorExtensions.cs" />
     <Compile Include="Model\ModelObjectExtensions.cs" />
     <Compile Include="Model\ModelObjectSelectorExtensions.cs" />
+    <Compile Include="Model\UI\ModelObjectSelectorExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Drawing\ViewBaseExtension.cs" />
     <Compile Include="Drawing\DrawingEnumeratorExtension.cs" />
     <Compile Include="Drawing\DrawingObjectEnumeratorExtension.cs" />
+    <Compile Include="Drawing\ViewExtensions.cs" />
     <Compile Include="Geometry3d\CoordinateSystemExtensions.cs" />
     <Compile Include="Geometry3d\Intersection2.cs" />
     <Compile Include="Geometry3d\MatrixExtensions.cs" />

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Model\ModelInfoExtensions.cs" />
     <Compile Include="Model\ModelObjectEnumeratorExtensions.cs" />
     <Compile Include="Model\ModelObjectExtensions.cs" />
+    <Compile Include="Model\ModelObjectSelectorExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
+++ b/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods/TeklaOpenAPIExtensionMethods.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Drawing\DrawingExtensions.cs" />
     <Compile Include="Drawing\DrawingObjectExtensions.cs" />
     <Compile Include="Drawing\DrawingObjectSelectorExtensions.cs" />
+    <Compile Include="Drawing\DrawingSelectorExtensions.cs" />
     <Compile Include="Drawing\ViewBaseExtension.cs" />
     <Compile Include="Drawing\DrawingEnumeratorExtension.cs" />
     <Compile Include="Drawing\DrawingObjectEnumeratorExtension.cs" />
@@ -114,6 +115,7 @@
   <ItemGroup>
     <None Include="Readme.md" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
+++ b/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
@@ -137,6 +137,9 @@
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Model\ModelObjectExtensions.cs">
       <Link>references\ModelObjectExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\TeklaOpenAPIExtensionMethods\Model\ModelObjectSelectorExtensions.cs">
+      <Link>references\ModelObjectSelectorExtensions.cs</Link>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
+++ b/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
@@ -104,6 +104,9 @@
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\DrawingObjectSelectorExtensions.cs">
       <Link>references\DrawingObjectSelectorExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\DrawingSelectorExtensions.cs">
+      <Link>references\DrawingSelectorExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\ViewBaseExtension.cs">
       <Link>references\ViewBaseExtension.cs</Link>
     </Compile>

--- a/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
+++ b/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
@@ -140,6 +140,9 @@
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Model\ModelObjectSelectorExtensions.cs">
       <Link>references\ModelObjectSelectorExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\TeklaOpenAPIExtensionMethods\Model\UI\ModelObjectSelectorExtensions.cs">
+      <Link>references\Model\UI\ModelObjectSelectorExtensions.cs</Link>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -147,6 +150,7 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
+++ b/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
@@ -83,6 +83,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\TeklaOpenAPIExtensionMethods\Collections\IEnumeratorExtensions.cs">
+      <Link>references\IEnumeratorExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\DrawingEnumeratorExtension.cs">
       <Link>references\DrawingEnumeratorExtension.cs</Link>
     </Compile>

--- a/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
+++ b/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
@@ -107,6 +107,9 @@
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\ViewBaseExtension.cs">
       <Link>references\ViewBaseExtension.cs</Link>
     </Compile>
+    <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\ViewExtensions.cs">
+      <Link>references\ViewExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Geometry3d\CoordinateSystemExtensions.cs">
       <Link>references\CoordinateSystemExtensions.cs</Link>
     </Compile>

--- a/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
+++ b/TeklaOpenAPIExtensionMethods/TestProject/TestProject.csproj
@@ -86,6 +86,9 @@
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Collections\IEnumeratorExtensions.cs">
       <Link>references\IEnumeratorExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\ContainerViewExtensions.cs">
+      <Link>references\ContainerViewExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\TeklaOpenAPIExtensionMethods\Drawing\DrawingEnumeratorExtension.cs">
       <Link>references\DrawingEnumeratorExtension.cs</Link>
     </Compile>


### PR DESCRIPTION
## Additions
Add a generic extension to convert IEnumerator to a read-only collection.

### Model
Add extensions to convert from ModelObjectEnumerator to a read-only collection.
Add extensions to select and try to select model objects from Tekla.Structures.Model.Model.

Add new extension method classes for..
1. Tekla.Structures.Model.ModelObjectSelector
2. Tekla.Structures.Model.UI.ModelObjectSelector

### Drawing
Add extensions to convert from DrawingObjectEnumerator and DrawingEnumerator to a read-only collection.

Add new extension classes for..
1. Tekla.Structures.Drawing.View
2. Tekla.Structures.Drawing.ContainerView
3. Tekla.Structures.Drawing.UI.DrawingSelector
4. Tekla.Structures.Drawing.UI.DrawingObjectSelector


